### PR TITLE
Update NodeJS version to 8.10

### DIFF
--- a/cloud/api.yaml
+++ b/cloud/api.yaml
@@ -252,7 +252,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       Policies: AmazonDynamoDBFullAccess
       Environment:
         Variables:


### PR DESCRIPTION
NodeJS 4.3 is deprecated, use version to 8.10 instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
