### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/cloud/api.yaml
+++ b/cloud/api.yaml
@@ -252,7 +252,7 @@ Resources:
     Properties:
       FunctionName: !Ref LambdaFunctionName
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Policies: AmazonDynamoDBFullAccess
       Environment:
         Variables:


### PR DESCRIPTION
CloudFormation templates in aws-serverless-ember have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.